### PR TITLE
Making the library work for all Into supported conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "to"
 version = "0.1.0"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>", "Nick Webster <nick@nick.geek.nz>"]
@@ -7,4 +6,4 @@ repository = "https://github.com/reem/rust-to.git"
 readme = "README.md"
 license = "MIT"
 description = "A trait for generalized conversion to a target type."
-
+edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 
 name = "to"
-version = "0.0.1"
-authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
+version = "0.1.0"
+authors = ["Jonathan Reem <jonathan.reem@gmail.com>", "Nick Webster <nick@nick.geek.nz>"]
 repository = "https://github.com/reem/rust-to.git"
 readme = "README.md"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,11 @@
 //! Generalized conversion to a target type.
 
 /// A type which can be converted to `X`.
-pub trait To<X> {
+trait To<X> : Into<X> {
     /// Convert self to an instance of `X`.
-    fn to(self) -> X;
+    fn to(self) -> X {
+        self.into()
+    }
 }
 
-impl<T> To<T> for T { fn to(self) -> T { self } }
-
+impl <U, T: Into<U>> To<U> for T {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
-#![license = "MIT"]
 #![deny(missing_docs, warnings)]
 
 //! Generalized conversion to a target type.
 
 /// A type which can be converted to `X`.
-trait To<X> : Into<X> {
+pub trait To<X> : Into<X> {
     /// Convert self to an instance of `X`.
     fn to(self) -> X {
         self.into()


### PR DESCRIPTION
Given the following code, the library won't work:
```rust
let mut data: Vec<String> = Vec::new();
data.push("A".to());
```
It'll keep `"A"` as a `&str`. I've changed the trait to effectively be a shorthand for `Into`, ensuring that it can actually convert to a target type.

It's effectively a breaking change, so it's okay if you just want to close. I just think this PR might be useful.